### PR TITLE
Add a demo shinyapps.io snippet for the _03_deploy_ file

### DIFF
--- a/inst/shinyexample/dev/03_deploy.R
+++ b/inst/shinyexample/dev/03_deploy.R
@@ -38,3 +38,23 @@ golem::add_dockerfile_with_renv()
 ## If you want to deploy to ShinyProxy
 golem::add_dockerfile_with_renv_shinyproxy()
 
+## ShinyApps.io Demo Deployment Snippet
+# If you want to deploy to ShinyApps.io without using the built in RStudio workflow
+rsconnect::deployApp(
+  appName = desc::desc_get_field("Package"),
+  appTitle = desc::desc_get_field("Package"),
+  appFiles = c(
+    # Add any additional files unique to your app here.
+    "R/",
+    "inst/",
+    "data/",
+    "NAMESPACE",
+    "DESCRIPTION",
+    "app.R",
+    ".Rprofile",
+    ".Renviron"
+  ),
+  appId = rsconnect::deployments(".")$appID,
+  lint = FALSE,
+  forceUpdate = TRUE
+)


### PR DESCRIPTION
As per @ColinFay 's request in #923, adds a snippet to _03_deploy.R_ that will deploy most shiny apps to shinyapps.io without the use of the RStudio built in workflow